### PR TITLE
Fix colour/armour spelling in en_gb and some typos

### DIFF
--- a/translations/locale_en_gb.json
+++ b/translations/locale_en_gb.json
@@ -68,8 +68,8 @@
 	"header": {
 		"settings": {
 			"colorblind": {
-				"input_name": "Colorblind mode",
-				"label": "Colorblind mode"
+				"input_name": "Colourblind mode",
+				"label": "Colourblind mode"
 			},
 			"difficulty": {
 				"limit_guesses_6": {
@@ -281,7 +281,7 @@
 				},
 				"partial_matches": {
 					"title": "Partial Match explanation",
-					"intro": "Let's look at partial matches in detail, 'cause these are probably the most confusing tile colors.",
+					"intro": "Let's look at partial matches in detail, 'cause these are probably the most confusing tile colours.",
 					"explanation": "A partial match can only appear in fields that consist of a list (e.g. Tools). If you guessed a block that can be broken with at least one tool that matches the actual block, you will get a partial match. Here's an example for leaves:"
 				},
 				"tips": {
@@ -424,12 +424,12 @@
 				},
 				"partial_matches": {
 					"title": "Partial Match explanation",
-					"intro": "Let's look at partial matches in detail, cause these are probably the most confusing tile colors.",
+					"intro": "Let's look at partial matches in detail, 'cause these are probably the most confusing tile colours.",
 					"explanation": "A partial match can only appear in fields that consist of a list (e.g. the inventory category). If you guessed a item that is in at least one inventory category that matches the actual item, you will get a partial match. Here's an example for string:"
 				},
 				"tips": {
 					"title": "Tips",
-					"not_all_items": "MCdle does not contain every type of item. The list is taken from the Minecraft wiki and as such does not contain the item forms of various blocks or too similar items, like all the armor/tool variants.",
+					"not_all_items": "MCdle does not contain every type of item. The list is taken from the Minecraft wiki and as such does not contain the item forms of various blocks or too similar items, like all the armour/tool variants.",
 					"utilize_the_search": "Make good use of the search bar! Looking through the suggestions will help you narrow down your search.",
 					"use_the_wiki": "Feel free to use the Minecraft wiki. As soon as you've determined the version of the item, you can use the wiki to find the items that were added in that version, which will help you narrow down your search drastically.",
 					"usage_and_source_explanation": "If you are curious how the Usage count/Source count is calculated, check the item's wiki page and scroll to \"Obtaining\" and \"Usage\". The headers of these sections have been used to count their different usecases. If they were missing, I, the developer, have added them manually."
@@ -569,16 +569,16 @@
 					"intro": "Let's look at an example game. First we'll try an arbitrary mob.",
 					"table_interpretation_1": "From this guess, we can see that the mob we're looking for is newer then 1.6.1, doesn't have a lot of health, is less then 1.6 blocks tall, and might be passive, hostile, or a mix with one of those two. It's not summoned by lightning and it's not undead either.",
 					"table_interpretation_2": "Alright, still newer than 1.13, but we got the health: we're looking for a mob with 10 HP, aka 5 hearts. It's less than 0.6 blocks tall, so we're looking for a small mob. The mob's behavior is still a partial match, so it's very likely passive, but could still be hostile & neutral. Both the spawn and classification fields got a partial match, so the mob's spawn origins would be biome and something else, and the mob would be classified as either animal, aquatic, and maybe something else in addition to one of these two possibilities.",
-					"table_interpretation_3": "Let's go! Look who hopped into this tutorial. We've found a little Frog!"
+					"table_interpretation_3": "Let's go! Look who hopped into this tutorial. We've found a little frog!"
 				},
 				"partial_matches": {
 					"title": "Partial Match explanation",
-					"intro": "Let's look at partial matches in detail, 'cause these are probably the most confusing tile colors.",
+					"intro": "Let's look at partial matches in detail, 'cause these are probably the most confusing tile colours.",
 					"explanation": "A partial match can only appear in fields that consist of a list (e.g. the spawn, classification, or behavior fields). If you guessed a mob with at least one list element that matches the actual mob, you will get a partial match. Here's an example for horses:"
 				},
 				"tips": {
 					"title": "Tips",
-					"not_all_blocks": "MCdle does not contain every type of entity. Only living entities, like e.g. pigs or zombies are included. Armor stands, projectiles, or similar not living entities are not included. The list is taken from the Minecraft wiki, so if it's not on there in the mob list, it's not in this game.",
+					"not_all_blocks": "MCdle does not contain every type of entity. Only living entities, like e.g. pigs or zombies are included. Armour stands, projectiles, or similar not living entities are not included. The list is taken from the Minecraft wiki, so if it's not on there in the mob list, it's not in this game.",
 					"utilize_the_search": "Make good use of the search bar! Looking through the suggestions will help you narrow down your search.",
 					"use_the_wiki": "Feel free to use the Minecraft wiki. As soon as you've determined the version of the mob, you can use the wiki to find the mobs that were added in that version, which will help you narrow down your search drastically.",
 					"health_measuring": "Keep in mind that health is measured in health points, aka half hearts, so 10 HP is 5 hearts."
@@ -654,7 +654,7 @@
 		"quick_help": {
 			"show_button": "Show quick help",
 			"color_explanation": {
-				"title": "Color explanation",
+				"title": "Colour explanation",
 				"correct": "Correct Field",
 				"incorrect": "Incorrect Field",
 				"partial": "Partially correct Field"
@@ -1067,7 +1067,7 @@
 		"clay_ball": "Clay Ball",
 		"clock": "Clock",
 		"coal": "Coal",
-		"armor_trim_smithing_template": "Armor Trim",
+		"armor_trim_smithing_template": "Armour Trim",
 		"cocoa_beans": "Cocoa Beans",
 		"cod": "Raw Cod",
 		"command_block_minecart": "Minecart with Command Block",

--- a/translations/locale_en_us.json
+++ b/translations/locale_en_us.json
@@ -286,7 +286,7 @@
 				},
 				"tips": {
 					"title": "Tips",
-					"not_all_blocks": "MCdle does not contain every type of block. All the coloured variants of concrete, terracotta, wool, etc. are merged into one representative block like \"Concrete\" or \"Wool\". This also applies to the different wood types, walls, stairs, etc.",
+					"not_all_blocks": "MCdle does not contain every type of block. All the colored variants of concrete, terracotta, wool, etc. are merged into one representative block like \"Concrete\" or \"Wool\". This also applies to the different wood types, walls, stairs, etc.",
 					"utilize_the_search": "Make good use of the search bar! Looking through the suggestions will help you narrow down your search.",
 					"use_the_wiki": "Feel free to use the Minecraft wiki. As soon as you've determined the version of the block, you can use the wiki to find the blocks that were added in that version, which will help you narrow down your search drastically."
 				}


### PR DESCRIPTION
I noticed that Armour Trim was not showing up in the item search in `en_gb` because it was Armor Trim.